### PR TITLE
 updated readme, nft fetch limit and header

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,6 @@ Open another tab in the terminal:
 The app is now running in the development mode.
 Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 
+This application uses the Moralis Web3 API. To run, please create a .env and add `MORALIS_API_KEY = <your_api_key>`.
+
 Enjoy!

--- a/client/src/components/Collections.js
+++ b/client/src/components/Collections.js
@@ -44,7 +44,7 @@ const Collections = () => {
   return (
     <div className='container'>
       <div className='container'>
-        <h1 className='font-effect-neon'>Nifty Gallery</h1>
+        <h1 className='font-effect-neon'>NIFTY GALLERY</h1>
         <form className='text-center d-flex' onSubmit={handleSubmit}>
             <input type='text' className='form-control' placeholder='Enter Ethereum Contract Address Here' value={address} onChange={(event) => setAddress(event.target.value)} />
           <button type='submit' className='btn btn-dark'>Submit</button>

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ app.get('/', async (req, res) => {
       const response = await Moralis.EvmApi.nft.getContractNFTs({
           address,
           chain,
-          limit: 12
+          limit: 20
         });
         res.json(response);
     } catch (error) {


### PR DESCRIPTION
- Readme contains instructions to add .env with api key from Moralis Web3
- Updated request handler limit to fetch up to 20 nfts per request
- capitalized header