### PR TITLE
bug fix - only render nfts with non null metadata property

### DIFF
--- a/client/src/components/Collections.js
+++ b/client/src/components/Collections.js
@@ -53,14 +53,16 @@ const Collections = () => {
       <div className='row row-cols-4 g-4'>
         {nftList && nftList.map(nft => {
           return (
-            <div className='col mb-4' key={nft.token_id}>
-              <div className='card bg-dark text-white h-100' style={{width: '18rem'}} onClick={() => handleOpenModal(nft)}>
-                <img className='card-img-top' alt='Thumbnail of NFTs by the given address' src={nft.metadata.image} />
-                <div className='card-body'>
-                  <h5 className='card-title'>{nft.metadata.name}</h5>
+            nft.metadata ? (
+              <div className='col mb-4' key={nft.token_id}>
+                <div className='card bg-dark text-white h-100' style={{width: '18rem'}} onClick={() => handleOpenModal(nft)}>
+                  <img className='card-img-top' alt='Thumbnail of NFTs by the given address' src={nft.metadata.image} />
+                  <div className='card-body'>
+                    <h5 className='card-title'>{nft.metadata.name}</h5>
+                  </div>
                 </div>
               </div>
-            </div>
+            ) : null
           )
         })}
       </div>


### PR DESCRIPTION
Page previously crashed when trying to render collection addresses with nfts that had a null metadata property. Added conditional to only create and render cards with a truthy metadata property.